### PR TITLE
Add docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Karl Swanson <karlcswanson@gmail.com>
 
 WORKDIR /usr/src/app
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install nodejs
 
 COPY . .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+  # -------- Micboard -----------
+  micboard:
+    image: micboard
+    container_name: micboard
+    ports:
+      - '8058:8058'
+    volumes:
+      - ~/Library/Application\ Support/micboard:/root/.local/share/micboard


### PR DESCRIPTION
Add docker-compose.yaml file for easier startup
Uses MacOS specific default directory for config
ie.   docker-compose up (for console logging)
or
docker-compose up --no-start;docker-compose start    (for no logging)