### PR TITLE
Fix setting of extended names and IDs

### DIFF
--- a/js/extended.js
+++ b/js/extended.js
@@ -47,7 +47,7 @@ function loadBulkNames() {
 
 function submitUpdate(data) {
   const url = 'api/slot';
-  postJSON(url, data, window.location.reload());
+  postJSON(url, data, () => window.location.reload());
 }
 
 function initSlotEdit() {


### PR DESCRIPTION
`window.location.reload()` was being called, rather than being passed as a callback. This was leading to the page being reloaded before the new names and IDs were transmitted to the server.